### PR TITLE
Add a "py3" tox test environment for /usr/bin/python3.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     py,
     py2.7,
+    py3,
     py3.2,
     py3.3,
     pypy
@@ -26,6 +27,10 @@ deps =
     {[base]deps}
 [testenv:py2.7]
 basepython = python2.7
+deps =
+    {[base]deps}
+[testenv:py3]
+basepython = python3
 deps =
     {[base]deps}
 [testenv:py3.2]


### PR DESCRIPTION
This goes with the "py" environment; I found it useful to have this when putting together a Debian package of python-tblib (thanks for this!).
