### PR TITLE
Add to_dict method and from_dict classmethod on Tracebacks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -199,6 +199,39 @@ It is used by the ``pickling_support``. You can use it too if you want more flex
         raise Exception('fail')
     Exception: fail
 
+
+You can use the ``to_dict`` method and the ``from_dict`` classmethod to
+convert a Traceback into and from a dictionary serializable by the stdlib
+json.JSONDecoder::
+
+    >>> import json
+    >>> from tblib import Traceback
+    >>> try:
+    ...     inner_2()
+    ... except:
+    ...     et, ev, tb = sys.exc_info()
+    ...     tb = Traceback(tb)
+    ...     tb_json = json.dumps(tb.to_dict())
+    ...     tb_2 = Traceback.from_dict(json.loads(tb_json))
+    ...     reraise(et, ev, tb.as_traceback())
+    ...
+    Traceback (most recent call last):
+      ...
+      File "<doctest README.rst[21]>", line 6, in <module>
+        reraise(et, ev, tb.as_traceback())
+      File "<doctest README.rst[21]>", line 2, in <module>
+        inner_2()
+      File "<doctest README.rst[5]>", line 2, in inner_2
+        inner_1()
+      File "<doctest README.rst[4]>", line 2, in inner_1
+        inner_0()
+      File "<doctest README.rst[3]>", line 2, in inner_0
+        raise Exception('fail')
+    Exception: fail
+
+
+
+
 Decorators
 ==========
 

--- a/src/tblib/__init__.py
+++ b/src/tblib/__init__.py
@@ -20,10 +20,7 @@ PY3 = sys.version_info[0] == 3
 
 class _AttrDict(dict):
     def __getattr__(self, attr):
-        try:
-            return self[attr]
-        except KeyError:
-            raise AttributeError('No {} attribute'.format(attr))
+        return self[attr]
 
 
 class __traceback_maker(Exception):

--- a/src/tblib/__init__.py
+++ b/src/tblib/__init__.py
@@ -110,7 +110,7 @@ class Traceback(object):
             for k, v in self.tb_frame.f_code.__dict__.items()
             if k.startswith('co_')
         }
-        code['co_lnotab'] = code['co_lnotab'].decode('latin1')
+        code['co_lnotab'] = ''
         frame = {
             'f_globals': self.tb_frame.f_globals,
             'f_code': code
@@ -132,7 +132,6 @@ class Traceback(object):
             ('f_globals', dct['tb_frame']['f_globals']),
             ('f_code', _AttrDict((k, v) for k, v in dct['tb_frame']['f_code'].items()))
         ))
-        frame['f_code']['co_lnotab'] = frame['f_code']['co_lnotab'].encode('latin1')
         tb = _AttrDict((
             ('tb_frame', frame),
             ('tb_lineno', dct['tb_lineno']),


### PR DESCRIPTION
This makes it possible to pass tblib.Traceback around as JSON/YAML, and easy to write custom JsonEncoder/JsonDecoder classes for that purpose.