### PR TITLE
Add support for PyPy3.5-5.7.1-beta.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+1.3.2 (unreleased)
+~~~~~~~~~~~~~~~~~~
+
+* Add support for PyPy3.5-5.7.1-beta. Previously ``AttributeError:
+  'Frame' object has no attribute 'clear'``  could be raised. See PyPy
+  issue `#2532 <https://bitbucket.org/pypy/pypy/issues/2532/pypy3-attributeerror-frame-object-has-no>`_.
+
 1.3.1 (2017-03-27)
 ~~~~~~~~~~~~~~~~~~
 

--- a/src/tblib/__init__.py
+++ b/src/tblib/__init__.py
@@ -51,6 +51,13 @@ class Frame(object):
         ])
         self.f_code = Code(frame.f_code)
 
+    def clear(self):
+        # For compatibility with PyPy 3.5;
+        # clear() was added to frame in Python 3.4
+        # and is called by traceback.clear_frames(), which
+        # in turn is called by unittest.TestCase.assertRaises
+        pass
+
 
 class Traceback(object):
 


### PR DESCRIPTION
Previously ``AttributeError: 'Frame' object has no attribute 'clear'``
could be raised if `traceback.clear_frames` was used an an unpickled traceback. See PyPy issue [#2532](https://bitbucket.org/pypy/pypy/issues/2532/pypy3-attributeerror-frame-object-has-no).

Adding this clear method to gevent lets the tests run.

I'm not sure how/if you'd like to test this, your .travis.yml isn't set up to test PyPy 3.5 at this time.