### PR TITLE
Remove unused keyword arguments from setup() in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,15 +59,4 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Utilities',
     ],
-    keywords=[
-        # eg: 'keyword1', 'keyword2', 'keyword3',
-    ],
-    install_requires=[
-        # eg: 'aspectlib==1.1.1', 'six>=1.7',
-    ],
-    extras_require={
-        # eg:
-        #   'rst': ['docutils>=0.11'],
-        #   ':python_version=="2.6"': ['argparse'],
-    },
 )


### PR DESCRIPTION
Looks like they were copied from an example.