### PR TITLE
Remove testing and support for end-of-life Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ matrix:
     - python: 2.7
       env:
         - TOXENV=py27,report,coveralls,codecov
-    - python: 3.3
-      env:
-        - TOXENV=py33,report,coveralls,codecov
     - python: 3.4
       env:
         - TOXENV=py34,report,coveralls,codecov

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+UNRELEASED
+~~~~~~~~~~
+
+* Remove support for end of life Python 3.3.
+
 1.3.2 (2017-04-09)
 ~~~~~~~~~~~~~~~~~~
 

--- a/ci/appveyor-bootstrap.py
+++ b/ci/appveyor-bootstrap.py
@@ -20,9 +20,6 @@ GET_PIP_PATH = "C:\get-pip.py"
 URLS = {
     ("2.7", "64"): BASE_URL + "2.7.10/python-2.7.13.amd64.msi",
     ("2.7", "32"): BASE_URL + "2.7.10/python-2.7.13.msi",
-    # NOTE: no .msi installer for 3.3.6
-    ("3.3", "64"): BASE_URL + "3.3.3/python-3.3.5.amd64.msi",
-    ("3.3", "32"): BASE_URL + "3.3.3/python-3.3.5.msi",
     ("3.4", "64"): BASE_URL + "3.4.3/python-3.4.6.amd64.msi",
     ("3.4", "32"): BASE_URL + "3.4.3/python-3.4.6.msi",
     ("3.5", "64"): BASE_URL + "3.5.0/python-3.5.3-amd64.exe",
@@ -33,8 +30,6 @@ URLS = {
 INSTALL_CMD = {
     # Commands are allowed to fail only if they are not the last command.  Eg: uninstall (/x) allowed to fail.
     "2.7": [["msiexec.exe", "/L*+!", "install.log", "/qn", "/x", "{path}"],
-            ["msiexec.exe", "/L*+!", "install.log", "/qn", "/i", "{path}", "TARGETDIR={home}"]],
-    "3.3": [["msiexec.exe", "/L*+!", "install.log", "/qn", "/x", "{path}"],
             ["msiexec.exe", "/L*+!", "install.log", "/qn", "/i", "{path}", "TARGETDIR={home}"]],
     "3.4": [["msiexec.exe", "/L*+!", "install.log", "/qn", "/x", "{path}"],
             ["msiexec.exe", "/L*+!", "install.log", "/qn", "/i", "{path}", "TARGETDIR={home}"]],

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 envlist =
     clean,
     check,
-    {py27,py33,py34,py35,py36,pypy},
+    {py27,py34,py35,py36,pypy},
     report,
     docs
 
@@ -13,7 +13,6 @@ basepython =
     pypy: {env:TOXPYTHON:pypy}
     pypy3: {env:TOXPYTHON:pypy3}
     {py27,docs,spell}: {env:TOXPYTHON:python2.7}
-    py33: {env:TOXPYTHON:python3.3}
     py34: {env:TOXPYTHON:python3.4}
     py35: {env:TOXPYTHON:python3.5}
     py36: {env:TOXPYTHON:python3.6}


### PR DESCRIPTION
Python 3.3.x has reached end-of-life. The final release was 3.3.7
released 2017-09-19. It is no longer receiving bug reports or bug fixes
including for security issues. It use should not be encouraged. Only
support fully support Python versions.

Additionally, the most recent pytest release has dropped support for
Python 3.3, making it incompatible. See:

https://docs.pytest.org/en/latest/changelog.html#pytest-3-3-0-2017-11-23

> Pytest no longer supports Python 2.6 and 3.3. Those Python versions are EOL for some time now and incur maintenance and compatibility costs on the pytest core team, and following up with the rest of the community we decided that they will no longer be supported starting on this version. Users which still require those versions should pin pytest to <3.3.