### PR TITLE
Fix flake8 error, "do not use bare except"

### DIFF
--- a/src/tblib/__init__.py
+++ b/src/tblib/__init__.py
@@ -112,7 +112,7 @@ class Traceback(object):
             # noinspection PyBroadException
             try:
                 exec(code, current.tb_frame.f_globals, {})
-            except:
+            except Exception:
                 next_tb = sys.exc_info()[2].tb_next
                 if top_tb is None:
                     top_tb = next_tb


### PR DESCRIPTION
Fixes error of the form:

```
./src/tblib/__init__.py:115:13: E722 do not use bare except
```

Using a bare excpet also catches unexpected events like memory errors, interrupts, system exit, and so on. Prefer `except Exception:` instead. For more details, see:

- https://docs.python.org/3/library/exceptions.html#Exception
- https://docs.python.org/3/library/exceptions.html#exception-hierarchy