### PR TITLE
Simplify setup.py; remove unnecessary py_modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,8 @@ from __future__ import print_function
 
 import io
 import re
-from glob import glob
-from os.path import basename
 from os.path import dirname
 from os.path import join
-from os.path import splitext
 
 from setuptools import find_packages
 from setuptools import setup
@@ -34,7 +31,6 @@ setup(
     url='https://github.com/ionelmc/python-tblib',
     packages=find_packages('src'),
     package_dir={'': 'src'},
-    py_modules=[splitext(basename(path))[0] for path in glob('src/*.py')],
     include_package_data=True,
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
The python-tblib is a Python package (multiple files) and not simply a
module (single file). This is correctly specified in setup.py by the
packages directive. There is no need to also list each individual file
as a Python module, the packages directive already handles that. For
additional information on these commands, see:

https://docs.python.org/3/distutils/setupscript.html#listing-individual-modules