### PR TITLE
Update pypy support

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -7,3 +7,4 @@ Authors
 * DRayX - https://github.com/DRayX
 * Jason Madden - https://github.com/jamadden
 * Jon Dufresne - https://github.com/jdufresne/
+* Arni Mar Jonsson - https://github.com/arnimarj

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ UNRELEASED
 ~~~~~~~~~~
 
 * Remove support for end of life Python 3.3.
+* Support for constructing Twisted Failure objects when re-raising pickled exceptions
 
 1.3.2 (2017-04-09)
 ~~~~~~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ UNRELEASED
 ~~~~~~~~~~
 
 * Remove support for end of life Python 3.3.
-* Support for constructing Twisted Failure objects when re-raising pickled exceptions
+* Fix to support constructing Twisted Failure objects when re-raising pickled exceptions whilst running PyPy2.7-5.10.
 
 1.3.2 (2017-04-09)
 ~~~~~~~~~~~~~~~~~~

--- a/src/tblib/__init__.py
+++ b/src/tblib/__init__.py
@@ -52,6 +52,7 @@ class Frame(object):
         }
         self.f_code = Code(frame.f_code)
         self.f_lineno = int(frame.f_lineno)
+        self.f_back = Frame(self.f_back) if self.f_back is not None else None
 
     def clear(self):
         # For compatibility with PyPy 3.5;

--- a/src/tblib/__init__.py
+++ b/src/tblib/__init__.py
@@ -114,7 +114,7 @@ class Traceback(object):
                     code.co_firstlineno, code.co_lnotab, (), ()
                 )
 
-            # noinspection PyBroadExceptionf
+            # noinspection PyBroadException
             try:
                 exec(code, current.tb_frame.f_globals, {})
             except Exception:

--- a/src/tblib/__init__.py
+++ b/src/tblib/__init__.py
@@ -52,7 +52,7 @@ class Frame(object):
         }
         self.f_code = Code(frame.f_code)
         self.f_lineno = int(frame.f_lineno)
-        self.f_back = Frame(self.f_back) if self.f_back is not None else None
+        self.f_back = Frame(frame.f_back) if frame.f_back is not None else None
 
     def clear(self):
         # For compatibility with PyPy 3.5;

--- a/src/tblib/__init__.py
+++ b/src/tblib/__init__.py
@@ -40,10 +40,6 @@ class Code(object):
     def __init__(self, code):
         self.co_filename = code.co_filename
         self.co_name = code.co_name
-        self.co_nlocals = code.co_nlocals
-        self.co_stacksize = code.co_stacksize
-        self.co_flags = code.co_flags
-        self.co_firstlineno = code.co_firstlineno
         self.co_code = code.co_code
 
 
@@ -57,7 +53,6 @@ class Frame(object):
 
         self.f_code = Code(frame.f_code)
         self.f_lineno = int(frame.f_lineno)
-        self.f_back = Frame(frame.f_back) if frame.f_back is not None else None
 
     def clear(self):
         # For compatibility with PyPy 3.5;

--- a/src/tblib/__init__.py
+++ b/src/tblib/__init__.py
@@ -50,7 +50,6 @@ class Frame(object):
             for k, v in frame.f_globals.items()
             if k in ("__file__", "__name__")
         }
-
         self.f_code = Code(frame.f_code)
         self.f_lineno = int(frame.f_lineno)
 


### PR DESCRIPTION
This PR fixes the use case of constructing a Twisted Failure object in the except clause when re-raising a tblib pickled exception, when running under pypy-2.7 5.10.

Example:

```python
from __future__ import print_function

import sys, pickle, six

from tblib import pickling_support
pickling_support.install()

from twisted.python.failure import Failure

def add_and_fail(a, b):
	if a + b == 3:
		raise ValueError('never add 1 and 2 you silly person')

	return a + b

def failing_func():
	return add_and_fail(1, 2)

def main():
	try:
		failing_func()from __future__ import print_function

import sys, pickle, six

from tblib import pickling_support
pickling_support.install()

from twisted.python.failure import Failure

def add_and_fail(a, b):
	if a + b == 3:
		raise ValueError('never add 1 and 2 you silly person')

	return a + b

def failing_func():
	return add_and_fail(1, 2)

def main():
	try:
		failing_func()
	except ValueError:
		s = pickle.dumps(sys.exc_info())
	else:
		raise RuntimeError('should not be here')

	s = pickle.loads(s)

	try:
		six.reraise(*s)
	except ValueError:
		f = Failure()

	print('message:', f.getErrorMessage())
	print('failure:', f)

if __name__ == '__main__':
	main()


	except ValueError:
		s = pickle.dumps(sys.exc_info())
	else:
		raise RuntimeError('should not be here')

	s = pickle.loads(s)

	try:
		six.reraise(*s)
	except ValueError:
		f = Failure()

	print('message:', f.getErrorMessage())
	print('failure:', f)

if __name__ == '__main__':
	main()
```