### PR TITLE
Use a dict to de-duplicate filenames, and thus reduce the size of the to_dict()

### DIFF
--- a/src/tblib/__init__.py
+++ b/src/tblib/__init__.py
@@ -140,10 +140,19 @@ class Traceback(object):
 
     def to_dict(self):
         """Convert a Traceback into a dictionary representation"""
+        # Create a compression dictionary, to be filled as we go, and stuff it
+        # into the top level.
+        zipper = {}
+        result = self._to_compressed_dict(zipper)
+        result['zip'] = zipper
+        return result
+
+    def _to_compressed_dict(self, zipper):
+        """Convert a Traceback into a dictionary with optimised filename storage"""
         if self.tb_next is None:
             tb_next = None
         else:
-            tb_next = self.tb_next.to_dict()
+            tb_next = self.tb_next._to_compressed_dict(zipper)
 
         code = {
             'co_filename': self.tb_frame.f_code.co_filename,
@@ -153,6 +162,9 @@ class Traceback(object):
             'f_globals': self.tb_frame.f_globals,
             'f_code': code,
         }
+
+        # Update the filename entries with integers.
+        code['co_filename'] = zipper.setdefault(code['co_filename'], len(zipper))
         return {
             'tb_frame': frame,
             'tb_lineno': self.tb_lineno,
@@ -161,11 +173,20 @@ class Traceback(object):
 
     @classmethod
     def from_dict(cls, dct):
+        # Have zip keyed by strings was ideal for JSON transport, now we need
+        # to switch to doing lookups the other way around.
+        zipper = {v: k for k, v in dct['zip'].items()}
+        return cls._from_compressed_dict(dct, zipper)
+
+    @classmethod
+    def _from_compressed_dict(cls, dct, zipper):
         if dct['tb_next']:
-            tb_next = cls.from_dict(dct['tb_next'])
+            tb_next = cls._from_compressed_dict(dct['tb_next'], zipper)
         else:
             tb_next = None
 
+        # Update the filename entries with strings.
+        dct['tb_frame']['f_code']['co_filename'] = zipper[dct['tb_frame']['f_code']['co_filename']]
         code = _AttrDict(
             co_filename=dct['tb_frame']['f_code']['co_filename'],
             co_name=dct['tb_frame']['f_code']['co_name'],


### PR DESCRIPTION
Here is the patch I had in mind for #37. I've left the doctest's failing like this so you can see what the functional change is (and also because I'm not yet familiar enough with doctest :-)):
```
367     >>> import json
368     >>> from pprint import pprint
369     >>> try:
Differences (unified diff with -expected +actual):
    @@ -1,17 +1,19 @@
    -{'tb_frame': {'f_code': {'co_filename': '<doctest README.rst[...]>',
    -                         'co_name': '<module>'},
    +{'tb_frame': {'f_code': {'co_filename': 3, 'co_name': '<module>'},
                   'f_globals': {'__name__': '__main__'}},
      'tb_lineno': 2,
    - 'tb_next': {'tb_frame': {'f_code': {'co_filename': ...
    -                                     'co_name': 'inner_2'},
    + 'tb_next': {'tb_frame': {'f_code': {'co_filename': 2, 'co_name': 'inner_2'},
                               'f_globals': {'__name__': '__main__'}},
                  'tb_lineno': 2,
    -             'tb_next': {'tb_frame': {'f_code': {'co_filename': ...
    +             'tb_next': {'tb_frame': {'f_code': {'co_filename': 1,
                                                      'co_name': 'inner_1'},
                                           'f_globals': {'__name__': '__main__'}},
                              'tb_lineno': 2,
    -                         'tb_next': {'tb_frame': {'f_code': {'co_filename': ...
    +                         'tb_next': {'tb_frame': {'f_code': {'co_filename': 0,
                                                                  'co_name': 'inner_0'},
                                                       'f_globals': {'__name__': '__main__'}},
                                          'tb_lineno': 2,
    -                                     'tb_next': None}}}}
    +                                     'tb_next': None}}},
    + 'zip': {'<doctest README.rst[3]>': 0,
    +         '<doctest README.rst[40]>': 3,
    +         '<doctest README.rst[4]>': 1,
    +         '<doctest README.rst[5]>': 2}}
```
The basic change is that the co_filename, which often contains non-trivial filenames and duplicates too, stores an integer instead, and an extra "zip" dict at the top level provides the de-dupe service.

One other thing: for reasons I don't quite understand, on my dev system, though not in these tests, the `f_globals` dict also has a `__file__` which I also took care of via "zip"...I don't understand why that field is not present here. It also stores the filename, and is a major cause of duplicates for my setup. (Yes, I'm baffled by this).