### PR TITLE
Remove all references to deprecated easy_install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ before_install:
 install:
   - pip install -U tox virtualenv
   - virtualenv --version
-  - easy_install --version
   - pip --version
   - tox --version
   - |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,7 +67,6 @@ init:
 install:
   - python -u ci\appveyor-bootstrap.py
   - '%PYTHON_HOME%\Scripts\virtualenv --version'
-  - '%PYTHON_HOME%\Scripts\easy_install --version'
   - '%PYTHON_HOME%\Scripts\pip --version'
   - '%PYTHON_HOME%\Scripts\tox --version'
 test_script:

--- a/ci/templates/.travis.yml
+++ b/ci/templates/.travis.yml
@@ -22,7 +22,6 @@ before_install:
 install:
   - pip install -U tox virtualenv
   - virtualenv --version
-  - easy_install --version
   - pip --version
   - tox --version
   - |

--- a/ci/templates/appveyor.yml
+++ b/ci/templates/appveyor.yml
@@ -36,7 +36,6 @@ init:
 install:
   - python -u ci\appveyor-bootstrap.py
   - '%PYTHON_HOME%\Scripts\virtualenv --version'
-  - '%PYTHON_HOME%\Scripts\easy_install --version'
   - '%PYTHON_HOME%\Scripts\pip --version'
   - '%PYTHON_HOME%\Scripts\tox --version'
 test_script:


### PR DESCRIPTION
easy_install is deprecated and its use is discouraged by PyPA:

https://setuptools.readthedocs.io/en/latest/easy_install.html

> Warning: Easy Install is deprecated. Do not use it. Instead use pip.

Follow upstream advice.