### PR TITLE
Add Python 3.8 to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ matrix:
     - python: '3.7'
       env:
         - TOXENV=py37,report,coveralls,codecov
+    - python: '3.8'
+      env:
+        - TOXENV=py38,report,coveralls,codecov
     - python: 'pypy'
       env:
         - TOXENV=pypy,report,coveralls,codecov

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         # uncomment if you test on these interpreters:

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     clean,
     check,
     docs,
-    {py27,py34,py35,py36,py37,pypy,pypy3},
+    py{27,34,35,36,37,38,py,py3},
     report
 
 [testenv]
@@ -30,7 +30,7 @@ deps =
     pytest-travis-fold
     pytest-cov
     six
-    {py27,py34,py35,py36,py37,pypy,pypy3}: twisted
+    py{27,34,35,36,37,38,py,py3}: twisted
 commands =
     {posargs:py.test --cov=tblib --cov-report=term-missing -vv tests README.rst}
 


### PR DESCRIPTION
Python 3.8 was released on October 14th, 2019.