### PR TITLE
Fix flake8 errors

### DIFF
--- a/tests/test_issue30.py
+++ b/tests/test_issue30.py
@@ -1,15 +1,17 @@
 import pickle
 import sys
 
-import six
 import pytest
-pytest.importorskip('twisted')
-from twisted.python.failure import Failure
+import six
 
-from tblib import pickling_support
+from tblib import pickling_support  # noqa: E402
+
+pytest.importorskip('twisted')
 
 
 def test_30():
+    from twisted.python.failure import Failure
+
     pickling_support.install()
 
     try:


### PR DESCRIPTION
Errors appeared as:

    tests/test_issue30.py:7:1: E402 module level import not at top of file
    tests/test_issue30.py:9:1: E402 module level import not at top of file

Move the uncertain import into the test function so all top level
imports can be at the top of the file.