### PR TITLE
Simplify Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-dist: xenial
 env:
   global:
     - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
@@ -27,10 +26,10 @@ matrix:
     - python: '3.7'
       env:
         - TOXENV=py37,report,coveralls,codecov
-    - python: 'pypy2.7-6.0'
+    - python: 'pypy'
       env:
         - TOXENV=pypy,report,coveralls,codecov
-    - python: 'pypy3.5-6.0'
+    - python: 'pypy3'
       env:
         - TOXENV=pypy3,report,coveralls,codecov
 before_install:


### PR DESCRIPTION
Can remove 'dist: xenial' as it is now the default.

Can use alias 'pypy2' and 'pypy3' for the latest available PyPy release.