### PR TITLE
Drop support for EOL Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ matrix:
     - python: '2.7'
       env:
         - TOXENV=py27,report,coveralls,codecov
-    - python: '3.4'
-      env:
-        - TOXENV=py34,report,coveralls,codecov
     - python: '3.5'
       env:
         - TOXENV=py35,report,coveralls,codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,17 +22,6 @@ environment:
       PYTHON_HOME: C:\Python27-x64
       PYTHON_VERSION: '2.7'
       PYTHON_ARCH: '64'
-    - TOXENV: 'py34,report,codecov'
-      TOXPYTHON: C:\Python34\python.exe
-      PYTHON_HOME: C:\Python34
-      PYTHON_VERSION: '3.4'
-      PYTHON_ARCH: '32'
-    - TOXENV: 'py34,report,codecov'
-      TOXPYTHON: C:\Python34-x64\python.exe
-      WINDOWS_SDK_VERSION: v7.1
-      PYTHON_HOME: C:\Python34-x64
-      PYTHON_VERSION: '3.4'
-      PYTHON_ARCH: '64'
     - TOXENV: 'py35,report,codecov'
       TOXPYTHON: C:\Python35\python.exe
       PYTHON_HOME: C:\Python35

--- a/ci/appveyor-bootstrap.py
+++ b/ci/appveyor-bootstrap.py
@@ -20,8 +20,6 @@ GET_PIP_PATH = "C:\get-pip.py"
 URLS = {
     ("2.7", "64"): BASE_URL + "2.7.13/python-2.7.13.amd64.msi",
     ("2.7", "32"): BASE_URL + "2.7.13/python-2.7.13.msi",
-    ("3.4", "64"): BASE_URL + "3.4.4/python-3.4.4.amd64.msi",
-    ("3.4", "32"): BASE_URL + "3.4.4/python-3.4.4.msi",
     ("3.5", "64"): BASE_URL + "3.5.4/python-3.5.4-amd64.exe",
     ("3.5", "32"): BASE_URL + "3.5.4/python-3.5.4.exe",
     ("3.6", "64"): BASE_URL + "3.6.2/python-3.6.2-amd64.exe",
@@ -30,8 +28,6 @@ URLS = {
 INSTALL_CMD = {
     # Commands are allowed to fail only if they are not the last command.  Eg: uninstall (/x) allowed to fail.
     "2.7": [["msiexec.exe", "/L*+!", "install.log", "/qn", "/x", "{path}"],
-            ["msiexec.exe", "/L*+!", "install.log", "/qn", "/i", "{path}", "TARGETDIR={home}"]],
-    "3.4": [["msiexec.exe", "/L*+!", "install.log", "/qn", "/x", "{path}"],
             ["msiexec.exe", "/L*+!", "install.log", "/qn", "/i", "{path}", "TARGETDIR={home}"]],
     "3.5": [["{path}", "/quiet", "TargetDir={home}"]],
     "3.6": [["{path}", "/quiet", "TargetDir={home}"]],

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
@@ -72,7 +71,7 @@ setup(
     keywords=[
         'traceback', 'debugging', 'exceptions',
     ],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     install_requires=[
         # eg: 'aspectlib==1.1.1', 'six>=1.7',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     clean,
     check,
     docs,
-    py{27,34,35,36,37,38,py,py3},
+    py{27,35,36,37,38,py,py3},
     report
 
 [testenv]
@@ -13,7 +13,6 @@ basepython =
     pypy: {env:TOXPYTHON:pypy}
     pypy3: {env:TOXPYTHON:pypy3}
     py27: {env:TOXPYTHON:python2.7}
-    py34: {env:TOXPYTHON:python3.4}
     py35: {env:TOXPYTHON:python3.5}
     {py36,docs,spell}: {env:TOXPYTHON:python3.6}
     py37: {env:TOXPYTHON:python3.7}
@@ -30,7 +29,7 @@ deps =
     pytest-travis-fold
     pytest-cov
     six
-    py{27,34,35,36,37,38,py,py3}: twisted
+    py{27,35,36,37,38,py,py3}: twisted
 commands =
     {posargs:py.test --cov=tblib --cov-report=term-missing -vv tests README.rst}
 


### PR DESCRIPTION
Python 3.4 is end-of-life. It is no longer receiving bug fixes,
including for security issues. Python 3.4 went EOL on March 18, 2019.

Supported: https://devguide.python.org/#status-of-python-branches
EOL: https://devguide.python.org/devcycle/#end-of-life-branches

Right now, testing on Python 3.4 fails with the error:

    ImportError: Twisted on Python 3 requires Python 3.5 or later.

Rather than spend time maintaining, skipping or fixing this test, remove
the end-of-life support to reduce testing time and maintenance.

Using pypinfo, we can see the PyPI download statistics for tblib from
the last month, which show low numbers for Python 3.4.

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 3.6            |  58.72% |        435,682 |
| 2.7            |  17.55% |        130,204 |
| 3.7            |  11.91% |         88,401 |
| 3.5            |  11.59% |         85,975 |
| 3.4            |   0.18% |          1,322 |
| 3.8            |   0.05% |            385 |
| 2.6            |   0.00% |             28 |
| 3.3            |   0.00% |              3 |
| Total          |         |        742,000 |

Python 3.4 users can continue installing older releases of tblib. Using
python_requires ensures pip users will install a compatible version with
the need to pin it.