### PR TITLE
Simplify setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,8 @@ from __future__ import print_function
 
 import io
 import re
-from glob import glob
-from os.path import basename
 from os.path import dirname
 from os.path import join
-from os.path import splitext
 
 from setuptools import find_packages
 from setuptools import setup
@@ -37,9 +34,6 @@ setup(
     url='https://github.com/ionelmc/python-tblib',
     packages=find_packages('src'),
     package_dir={'': 'src'},
-    py_modules=[splitext(basename(path))[0] for path in glob('src/*.py')],
-    include_package_data=True,
-    zip_safe=False,
     classifiers=[
         # complete classifier list: http://pypi.python.org/pypi?%3Aaction=list_classifiers
         'Development Status :: 5 - Production/Stable',
@@ -58,10 +52,6 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
-        # uncomment if you test on these interpreters:
-        # 'Programming Language :: Python :: Implementation :: IronPython',
-        # 'Programming Language :: Python :: Implementation :: Jython',
-        # 'Programming Language :: Python :: Implementation :: Stackless',
         'Topic :: Utilities',
     ],
     project_urls={
@@ -73,12 +63,4 @@ setup(
         'traceback', 'debugging', 'exceptions',
     ],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
-    install_requires=[
-        # eg: 'aspectlib==1.1.1', 'six>=1.7',
-    ],
-    extras_require={
-        # eg:
-        #   'rst': ['docutils>=0.11'],
-        #   ':python_version=="2.6"': ['argparse'],
-    },
 )


### PR DESCRIPTION
As this tblib is installed as a Python package, setup.py should use the
'packages' keyword (which it already does) and not 'py_modules'. It is
redundant and unnecessary, so remove it.

This library doesn't have any package data, so don't bother with
'include_package_data'.

This package is just pure Python files, so it is zip safe. Don't bother
setting 'zip_safe' to False.

Remove trove classifiers for older Python implementations that are not
supported.

Remove empty keywords 'install_requires' and 'extras_require'. They are
just noise.