### PR TITLE
Added disable/enable_stringify_locals to pickling_support

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,3 +11,4 @@ Authors
 * Victor Stinner - https://github.com/vstinner
 * Guido Imperiale - https://github.com/crusaderky
 * Ivanq - https://github.com/imachug
+* Marco Ribeiro - https://marcoribeiro.me/

--- a/README.rst
+++ b/README.rst
@@ -393,6 +393,44 @@ forcing the type and value to have consistency across platforms)::
       ...
     RuntimeError: maximum recursion depth exceeded
 
+Pickling Exceptions together with their local variables in string form
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+    >>> from pprint import pprint
+    >>> from tblib import pickling_support
+    >>> pickling_support.install()
+    >>> pickling_support.enable_stringify_locals()
+    >>> import pickle, sys
+    >>> def gen_func():
+    ...     for i in range(5):
+    ...         yield i
+    ...
+    >>> def func(a, b, c, d, *args, **kwargs):
+    ...     f = object()
+    ...     g = gen_func()
+    ...     raise Exception('fail')
+    ...
+    >>> try:
+    ...     func(1, True, "c", range(10), "hi", Exception(), kw=())
+    ... except:
+    ...     buf = pickle.dumps(sys.exc_info(), protocol=pickle.HIGHEST_PROTOCOL)
+    ...
+    >>> exc_type, exc_obj, exc_tb = pickle.loads(buf)
+    >>> pprint(exc_tb.tb_next.tb_frame.f_locals)  # doctest: +SKIP
+    {'a': '1',
+     'args': "('hi', Exception())",
+     'b': 'True',
+     'c': "'c'",
+     'd': 'range(0, 10)',
+     'f': '<object object at 0x7f21890aeb50>',
+     'g': '<generator object gen_func at 0x7f21857bdf20>',
+     'kwargs': "{'kw': ()}"}
+
+This is useful for printing purposes, where the variable itself is not that
+important, but its representation is. An example of such use-case is tracing.
+
 Reference
 ~~~~~~~~~
 

--- a/src/tblib/__init__.py
+++ b/src/tblib/__init__.py
@@ -74,6 +74,8 @@ class Frame(object):
     """
     Class that replicates just enough of the builtin Frame object to enable serialization and traceback rendering.
     """
+    stringify_locals = False
+
     def __init__(self, frame):
         self.f_locals = {}
         self.f_globals = {
@@ -83,6 +85,12 @@ class Frame(object):
         }
         self.f_code = Code(frame.f_code)
         self.f_lineno = frame.f_lineno
+
+        if Frame.stringify_locals:
+            self.f_locals = {
+                k: repr(v)
+                for k, v in getattr(frame, "f_locals", {}).items()
+            }
 
     def clear(self):
         """
@@ -168,7 +176,7 @@ class Traceback(object):
 
             # noinspection PyBroadException
             try:
-                exec(code, dict(current.tb_frame.f_globals), {})
+                exec(code, dict(current.tb_frame.f_globals), dict(current.tb_frame.f_locals))
             except Exception:
                 next_tb = sys.exc_info()[2].tb_next
                 if top_tb is None:

--- a/src/tblib/pickling_support.py
+++ b/src/tblib/pickling_support.py
@@ -54,6 +54,14 @@ def _get_subclasses(cls):
         to_visit += list(this.__subclasses__())
 
 
+def enable_stringify_locals():
+    Frame.stringify_locals = True
+
+
+def disable_stringify_locals():
+    Frame.stringify_locals = False
+
+
 def install(*exc_classes_or_instances):
     copyreg.pickle(TracebackType, pickle_traceback)
 


### PR DESCRIPTION
Those functions are useful when you need to pass the frames along with a representation of the local variables on a stack, such as on tracing.
I also added an example of usage to the `README.rst` file.
On the future, this functionality can be expanded as being proposed on #41, where only non-pickable variables may be converted to string.
It looks like only the [checks for the docs](https://travis-ci.org/github/ionelmc/python-tblib/jobs/678618115) are failing here, but [they were already failing](https://travis-ci.org/github/ionelmc/python-tblib/jobs/660136280) on master branch.