### PR TITLE
test_pickle_exception: even harder location stripping. Ref #74.

### DIFF
--- a/tests/test_pickle_exception.py
+++ b/tests/test_pickle_exception.py
@@ -30,7 +30,9 @@ class CustomError(Exception):
 
 
 def strip_locations(tb_text):
-    return tb_text.replace('    ~~^~~\n', '').replace('    ^^^^^^^^^^^^^^^^^\n', '')
+    lines = tb_text.splitlines()
+    lines = [line for line in lines if '~~^~~' not in line and '^^^^' not in line]
+    return '\n'.join(lines)
 
 
 @pytest.mark.parametrize('protocol', [None, *list(range(1, pickle.HIGHEST_PROTOCOL + 1))])


### PR DESCRIPTION
With Python 3.13, we need to strip even harder, because we get location lines with differing amounts of tildes and up carets in them, e.g.:

    ~~^~~~~

and:

    ^^^^^^^

Let's ditch the regex and instead go line-by-line with a pretty loose match for anything that looks like a location line.