### PR TITLE
Improve `as_traceback` performance

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,3 +13,4 @@ Authors
 * Alisa Sireneva - https://github.com/purplesyringa
 * Michał Górny - https://github.com/mgorny
 * Tim Maxwell - https://github.com/tmaxwell-anthropic
+* Haoyu Weng - https://github.com/wengh

--- a/src/tblib/__init__.py
+++ b/src/tblib/__init__.py
@@ -1,6 +1,5 @@
 import re
 import sys
-from types import CodeType
 
 __version__ = '3.0.0'
 __all__ = 'Traceback', 'TracebackParseError', 'Frame', 'Code'
@@ -124,34 +123,14 @@ class Traceback:
         )
         while current:
             f_code = current.tb_frame.f_code
-            if hasattr(stub, 'replace'):
-                # Python 3.8 and newer
-                code = stub.replace(
-                    co_firstlineno=current.tb_lineno,
-                    co_argcount=0,
-                    co_filename=f_code.co_filename,
-                    co_name=f_code.co_name,
-                    co_freevars=(),
-                    co_cellvars=(),
-                )
-            else:
-                code = CodeType(
-                    0,
-                    stub.co_kwonlyargcount,
-                    stub.co_nlocals,
-                    stub.co_stacksize,
-                    stub.co_flags,
-                    stub.co_code,
-                    stub.co_consts,
-                    stub.co_names,
-                    stub.co_varnames,
-                    f_code.co_filename,
-                    f_code.co_name,
-                    current.tb_lineno,
-                    stub.co_lnotab,
-                    (),
-                    (),
-                )
+            code = stub.replace(
+                co_firstlineno=current.tb_lineno,
+                co_argcount=0,
+                co_filename=f_code.co_filename,
+                co_name=f_code.co_name,
+                co_freevars=(),
+                co_cellvars=(),
+            )
 
             # noinspection PyBroadException
             try:

--- a/src/tblib/__init__.py
+++ b/src/tblib/__init__.py
@@ -117,27 +117,38 @@ class Traceback:
         current = self
         top_tb = None
         tb = None
+        stub = compile(
+            'raise __traceback_maker',
+            '<string>',
+            'exec',
+        )
         while current:
             f_code = current.tb_frame.f_code
-            code = compile('\n' * (current.tb_lineno - 1) + 'raise __traceback_maker', current.tb_frame.f_code.co_filename, 'exec')
-            if hasattr(code, 'replace'):
+            if hasattr(stub, 'replace'):
                 # Python 3.8 and newer
-                code = code.replace(co_argcount=0, co_filename=f_code.co_filename, co_name=f_code.co_name, co_freevars=(), co_cellvars=())
+                code = stub.replace(
+                    co_firstlineno=current.tb_lineno,
+                    co_argcount=0,
+                    co_filename=f_code.co_filename,
+                    co_name=f_code.co_name,
+                    co_freevars=(),
+                    co_cellvars=(),
+                )
             else:
                 code = CodeType(
                     0,
-                    code.co_kwonlyargcount,
-                    code.co_nlocals,
-                    code.co_stacksize,
-                    code.co_flags,
-                    code.co_code,
-                    code.co_consts,
-                    code.co_names,
-                    code.co_varnames,
+                    stub.co_kwonlyargcount,
+                    stub.co_nlocals,
+                    stub.co_stacksize,
+                    stub.co_flags,
+                    stub.co_code,
+                    stub.co_consts,
+                    stub.co_names,
+                    stub.co_varnames,
                     f_code.co_filename,
                     f_code.co_name,
-                    code.co_firstlineno,
-                    code.co_lnotab,
+                    current.tb_lineno,
+                    stub.co_lnotab,
                     (),
                     (),
                 )

--- a/tests/test_tblib.py
+++ b/tests/test_tblib.py
@@ -111,6 +111,18 @@ KeyboardInterrupt"""
     assert tb4.as_dict() == tb3.as_dict() == tb2.as_dict() == tb1.as_dict() == expected_dict
 
 
+def test_large_line_number():
+    line_number = 2**31 - 1
+    tb1 = Traceback.from_string(
+        f"""
+Traceback (most recent call last):
+  File "file1", line {line_number}, in <module>
+    code1
+"""
+    ).as_traceback()
+    assert tb1.tb_lineno == line_number
+
+
 def test_pytest_integration(testdir):
     test = testdir.makepyfile(
         """


### PR DESCRIPTION
This PR improves `Traceback.as_traceback()` performance by calling `compile` only once. This leads to ~50% speedup for long tracebacks.

Instead of setting the line number by adding blank lines, we now do it by changing `co_firstlineno`. This change also stops pathological input (e.g. `File "tests/examples.py", line 2147483647, in func_a`) from causing slowdown or blowing up memory.