### PR TITLE
Handle optional `TimeoutError` attributes

### DIFF
--- a/src/tblib/pickling_support.py
+++ b/src/tblib/pickling_support.py
@@ -70,7 +70,12 @@ def pickle_exception(
         }
         args = ()
         if isinstance(obj, OSError):
-            attrs.update(errno=obj.errno, strerror=obj.strerror)
+            # Only set OSError-specific attributes if they are not None
+            # Setting them to None explicitly breaks the string representation
+            if obj.errno is not None:
+                attrs['errno'] = obj.errno
+            if obj.strerror is not None:
+                attrs['strerror'] = obj.strerror
             if (winerror := getattr(obj, 'winerror', None)) is not None:
                 attrs['winerror'] = winerror
             if obj.filename is not None:


### PR DESCRIPTION
In https://github.com/dask/distributed/issues/9140 we are seeing a problem in our CI with newer versions of `tblib`.

It looks like this was partially fixed in #83 but the same applies to other attributes of `OSError` subclasses like `TimeoutError`, e.g `errorno` and `strerror`. If the value of them is `None` they should not be set at all otherwise it will break the string representation.